### PR TITLE
CI: allow manual dispatch for post-publish smoke check

### DIFF
--- a/.github/workflows/post_publish_smoke.yml
+++ b/.github/workflows/post_publish_smoke.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Run import smoke check
         run: |
-          docker run --rm ghcr.io/tschmidt95/florida-scraper:${{ github.event.release.tag_name }} \
+          docker run --rm ghcr.io/tschmidt95/florida-scraper:${CHECK_TAG} \
             python - <<'PY'
           import importlib.util, sys
           spec = importlib.util.find_spec("florida_property_scraper")


### PR DESCRIPTION
Adds  with an optional  input so the post-publish smoke check can be manually run against a specific tag (useful for testing and reruns).