### PR TITLE
CI: fix delayed-retry condition for post-publish smoke check

### DIFF
--- a/.github/workflows/post_publish_smoke.yml
+++ b/.github/workflows/post_publish_smoke.yml
@@ -67,7 +67,7 @@ jobs:
   delayed-retry:
     needs: smoke-check
     runs-on: ubuntu-latest
-    if: ${{ needs.smoke-check.result == 'failure' }}
+    if: ${{ needs.smoke-check.conclusion == 'failure' }}
     env:
       CHECK_TAG: ${{ github.event.inputs.tag || github.event.release.tag_name }}
     steps:


### PR DESCRIPTION
Change the delayed-retry 'if' to use needs.smoke-check.conclusion == 'failure' so the job runs when the initial smoke-check fails.