### PR TITLE
CI: ensure delayed retry runs only when needed (runtime check)

### DIFF
--- a/.github/workflows/post_publish_smoke.yml
+++ b/.github/workflows/post_publish_smoke.yml
@@ -67,10 +67,18 @@ jobs:
   delayed-retry:
     needs: smoke-check
     runs-on: ubuntu-latest
-    if: ${{ needs.smoke-check.conclusion == 'failure' }}
+    if: ${{ always() }}
     env:
       CHECK_TAG: ${{ github.event.inputs.tag || github.event.release.tag_name }}
     steps:
+      - name: Check whether initial smoke-check failed
+        run: |
+          echo "Initial job conclusion: '${{ needs.smoke-check.conclusion }}'"
+          if [ "${{ needs.smoke-check.conclusion }}" != "failure" ]; then
+            echo "Previous smoke-check did not fail; skipping delayed retry."
+            exit 0
+          fi
+
       - name: Checkout repo
         uses: actions/checkout@v4
 


### PR DESCRIPTION
Make  run always and inspect  at runtime so it only retries when the initial smoke-check failed; avoids job being skipped unexpectedly.