### PR TITLE
CI: increase post-publish retries, add daily image monitor, and docs

### DIFF
--- a/.github/workflows/image_monitor.yml
+++ b/.github/workflows/image_monitor.yml
@@ -1,0 +1,60 @@
+name: Image monitor
+
+on:
+  schedule:
+    - cron: '0 2 * * *' # daily at 02:00 UTC
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to check (default: latest)'
+        required: false
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  monitor:
+    runs-on: ubuntu-latest
+    env:
+      CHECK_TAG: ${{ github.event.inputs.tag || 'latest' }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull image (with limited retries)
+        run: |
+          set -euo pipefail
+          TAG="${CHECK_TAG}"
+          REPO=ghcr.io/tschmidt95/florida-scraper
+          ATTEMPTS=6
+          SLEEP=15
+          i=1
+          until docker pull "${REPO}:${TAG}"; do
+            if [ "$i" -ge "$ATTEMPTS" ]; then
+              echo "ERROR: failed to pull ${REPO}:${TAG} after ${ATTEMPTS} attempts"
+              echo "Check publish runs: https://github.com/${{ github.repository }}/actions/runs?query=tag%3A${TAG}"
+              exit 1
+            fi
+            echo "Pull failed, waiting ${SLEEP}s before retry ($i/$ATTEMPTS)..."
+            i=$((i+1))
+            sleep "$SLEEP"
+          done
+
+      - name: Run import smoke check
+        run: |
+          docker run --rm ghcr.io/tschmidt95/florida-scraper:${CHECK_TAG} python - <<'PY'
+          import importlib.util, sys
+          spec = importlib.util.find_spec("florida_property_scraper")
+          if spec is None:
+              print("ERROR: import failed")
+              sys.exit(2)
+          print("OK:", spec.origin)
+          PY

--- a/.github/workflows/post_publish_smoke.yml
+++ b/.github/workflows/post_publish_smoke.yml
@@ -34,8 +34,8 @@ jobs:
           set -euo pipefail
           TAG="${CHECK_TAG}"
           REPO=ghcr.io/tschmidt95/florida-scraper
-          ATTEMPTS=8
-          SLEEP=15
+          ATTEMPTS=12
+          SLEEP=20
           i=1
           until docker pull "${REPO}:${TAG}"; do
             if [ "$i" -ge "$ATTEMPTS" ]; then
@@ -95,10 +95,10 @@ jobs:
           set -euo pipefail
           TAG="${CHECK_TAG}"
           REPO=ghcr.io/tschmidt95/florida-scraper
-          echo "Initial check failed; waiting 60s before retry..."
-          sleep 60
-          ATTEMPTS=6
-          SLEEP=10
+          echo "Initial check failed; waiting 90s before retry..."
+          sleep 90
+          ATTEMPTS=8
+          SLEEP=15
           i=1
           until docker pull "${REPO}:${TAG}"; do
             if [ "$i" -ge "$ATTEMPTS" ]; then

--- a/README.md
+++ b/README.md
@@ -16,4 +16,8 @@ Replace `<owner>/<repo>` and `<your-tag>` with the repository and tag to inspect
 
 If you want, you can also dispatch the workflow manually with the `tag` of a known-published image for immediate verification.
 
+### Scheduled image monitoring
+
+A daily scheduled job runs at 02:00 UTC and checks `ghcr.io/tschmidt95/florida-scraper:latest` by default (it can be dispatched manually with a specific `tag`). This provides ongoing verification that published images remain importable.
+
 ---


### PR DESCRIPTION
Increase retry/backoff in post-publish smoke check, add a scheduled daily image monitor workflow (runs at 02:00 UTC and supports manual dispatch), and document monitoring in README.

This makes publish verification more robust and provides ongoing checks of the published images.,