### PR TITLE
CI: add notification template for monitor-failure (placeholder webhook)

### DIFF
--- a/.github/workflows/notify_placeholder.yml
+++ b/.github/workflows/notify_placeholder.yml
@@ -1,0 +1,45 @@
+name: Notify on monitor-failure (template)
+
+on:
+  issues:
+    types: [opened, labeled]
+
+permissions:
+  issues: read
+  secrets: read
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    if: |
+      contains(github.event.issue.labels.*.name, 'monitor-failure')
+    steps:
+      - name: Show placeholder notice
+        run: |
+          echo "This workflow is a template. It will send notifications to the destination defined in the ALERT_WEBHOOK_URL secret when enabled."
+
+      - name: Fail early if no webhook configured (no-op placeholder)
+        run: |
+          if [ -z "${{ secrets.ALERT_WEBHOOK_URL }}" ]; then
+            echo "No ALERT_WEBHOOK_URL is configured. This is a template placeholder; add the secret to enable notifications."
+            exit 0
+          fi
+
+      - name: Send notification to webhook (example)
+        if: ${{ secrets.ALERT_WEBHOOK_URL != '' }}
+        env:
+          ALERT_URL: ${{ secrets.ALERT_WEBHOOK_URL }}
+        run: |
+          ISSUE_URL="${{ github.event.issue.html_url }}"
+          ISSUE_TITLE="${{ github.event.issue.title }}"
+          ISSUE_BODY=$(jq -Rs . <<< "${{ github.event.issue.body }}")
+
+          # Example payload for Slack incoming webhook; adjust as needed for your destination.
+          payload=$(jq -n --arg title "$ISSUE_TITLE" --arg url "$ISSUE_URL" --arg body "$ISSUE_BODY" '{text: ("[ALERT] " + $title + "\n" + $url + "\n" + ($body | fromjson? // $body)) }')
+
+          echo "Sending notification to webhook..."
+          curl -sS -X POST -H 'Content-Type: application/json' -d "$payload" "$ALERT_URL" || true
+          echo "Notification step completed (response ignored)."
+
+      - name: Done
+        run: echo "Notification placeholder workflow executed."

--- a/README.md
+++ b/README.md
@@ -22,4 +22,12 @@ A daily scheduled job runs at 02:00 UTC and checks `ghcr.io/tschmidt95/florida-s
 
 If the scheduled monitor fails repeatedly (default threshold: 3 consecutive failures), an automatic GitHub Issue will be created (label `monitor-failure`) to notify maintainers and centralize triage.
 
+### Optional: External notifications (template)
+
+We provide a **template** workflow that can send an external notification (Slack, Microsoft Teams, webhook endpoints) when an issue labeled `monitor-failure` is opened.
+
+- File: `.github/workflows/notify_placeholder.yml`
+- How to enable: add a repository secret named `ALERT_WEBHOOK_URL` with your webhook URL (Slack, Teams, or custom). The workflow uses a simple POST payload; you may need to adjust the payload format depending on your destination.
+- Notes: the template is intentionally non-invasive (it exits if `ALERT_WEBHOOK_URL` is not configured). When you add the secret, the workflow will start posting notifications on new `monitor-failure` issues.
+
 ---


### PR DESCRIPTION
Adds a non-invasive template workflow () that will post to  when an issue with label  is opened. The workflow exits harmlessly if the secret is not provided; adjust payload for Slack/Teams as needed. This PR also documents the setup in the README.,