### PR TITLE
CI: notify template — add rich Slack Blocks and Teams card payloads

### DIFF
--- a/.github/workflows/notify_placeholder.yml
+++ b/.github/workflows/notify_placeholder.yml
@@ -44,10 +44,12 @@ jobs:
           echo "Sending notification using provider: $PROVIDER"
 
           if [ "$PROVIDER" = "slack" ]; then
-            payload=$(jq -n --arg title "$ISSUE_TITLE" --arg url "$ISSUE_URL" --arg body "$ISSUE_BODY" '{text: (":rotating_light: *" + $title + "*\n" + $url + "\n" + ($body | fromjson? // $body)) }')
+            # Slack Blocks payload (rich message with button)
+            payload=$(jq -n --arg title "$ISSUE_TITLE" --arg url "$ISSUE_URL" --arg body_raw "$ISSUE_BODY_RAW" \
+              '{blocks: [ {type: "section", text: {type: "mrkdwn", text: (":rotating_light: *" + $title + "*\n" + ($body_raw | fromjson? // $body_raw))}}, {type: "section", fields: [{type: "mrkdwn", text: "*Repo:* '" + "'${GITHUB_REPOSITORY}'" + "'"}, {type: "mrkdwn", text: "*Issue:* <" + $url + "|" + $title + ">"}]}, {type: "actions", elements: [{type: "button", text: {type: "plain_text", text: "View issue"}, url: $url}]}] }')
           elif [ "$PROVIDER" = "teams" ]; then
-            # Simple Teams message card text
-            payload=$(jq -n --arg title "$ISSUE_TITLE" --arg url "$ISSUE_URL" --arg body "$ISSUE_BODY" '{text: ("**" + $title + "**\n" + $url + "\n" + ($body | fromjson? // $body)) }')
+            # Teams message card with action button
+            payload=$(jq -n --arg title "$ISSUE_TITLE" --arg url "$ISSUE_URL" --arg body_raw "$ISSUE_BODY_RAW" '{title: $title, text: ($body_raw | fromjson? // $body_raw), potentialAction: [{"@type": "OpenUri", name: "View issue", targets: [{os: "default", uri: $url}]}]}')
           else
             # Generic structured payload
             payload=$(jq -n --arg title "$ISSUE_TITLE" --arg url "$ISSUE_URL" --arg body "$ISSUE_BODY" '{alert_type: "image_monitor_failure", title: $title, url: $url, body: ($body | fromjson? // $body)}')

--- a/README.md
+++ b/README.md
@@ -31,8 +31,10 @@ We provide a **template** workflow that can send an external notification (Slack
 - Notes: the template is intentionally non-invasive (it exits if `ALERT_WEBHOOK_URL` is not configured). When you add the secret, the workflow will start posting notifications on new `monitor-failure` issues.
 
 Testing:
-1. Add secrets `ALERT_WEBHOOK_URL` (required) and optionally `ALERT_PROVIDER` (`slack` or `teams`).
+1. Add secrets `ALERT_WEBHOOK_URL` (required) and optionally `ALERT_PROVIDER` (`slack`, `teams`, or `generic`).
 2. Create a test issue with label `monitor-failure` to trigger the notification.
-3. The workflow will send a JSON payload appropriate for the selected provider and log the webhook response status and a short response body excerpt in the action logs (helps with debugging).
+3. The workflow will send a provider-specific payload (Slack Blocks for `slack`, actionable card for `teams`) and log the webhook response status and a short response body excerpt in the action logs (helps with debugging).
+4. If you want a richer Slack message (blocks with button), use `ALERT_PROVIDER=slack` (default). For Teams actionable card use `ALERT_PROVIDER=teams`.
+
 
 ---


### PR DESCRIPTION
Enhance the notification template to send richer Slack Blocks messages (with a button) and Teams actionable card payloads when  is set to  or . README updated with provider guidance and test steps.,