### PR TITLE
CI: add notify test-harness (ALERT_WEBHOOK_URL_TEST) + docs

### DIFF
--- a/.github/workflows/notify_placeholder.yml
+++ b/.github/workflows/notify_placeholder.yml
@@ -30,6 +30,19 @@ jobs:
           echo "PROVIDER=$PROVIDER" >> $GITHUB_ENV
           echo "WEBHOOK_URL=${{ secrets.ALERT_WEBHOOK_URL }}" >> $GITHUB_ENV
 
+      - name: Optional: send test payload to ALERT_WEBHOOK_URL_TEST
+        if: ${{ secrets.ALERT_WEBHOOK_URL_TEST != '' }}
+        run: |
+          set -euo pipefail
+          TEST_URL='${{ secrets.ALERT_WEBHOOK_URL_TEST }}'
+          echo 'Sending test payload to ALERT_WEBHOOK_URL_TEST...'
+          payload=$(jq -n --arg repo "${{ github.repository }}" --arg issue "${{ github.event.issue.html_url }}" '{test: true, repo: $repo, issue: $issue, note: "Test alert from notify template"}')
+          RESP_FILE="/tmp/notify_test_resp_$$.txt"
+          STATUS_CODE=$(curl -sS -w "%{http_code}" -o "$RESP_FILE" -X POST -H 'Content-Type: application/json' -d "$payload" "$TEST_URL" || true)
+          echo "Test webhook response status: $STATUS_CODE"
+          echo "Test response body (first 500 chars):"
+          head -c 500 "$RESP_FILE" || true
+
       - name: Build and send notification payload
         run: |
           set -euo pipefail

--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ We provide a **template** workflow that can send an external notification (Slack
 
 Testing:
 1. Add secrets `ALERT_WEBHOOK_URL` (required) and optionally `ALERT_PROVIDER` (`slack`, `teams`, or `generic`).
-2. Create a test issue with label `monitor-failure` to trigger the notification.
-3. The workflow will send a provider-specific payload (Slack Blocks for `slack`, actionable card for `teams`) and log the webhook response status and a short response body excerpt in the action logs (helps with debugging).
-4. If you want a richer Slack message (blocks with button), use `ALERT_PROVIDER=slack` (default). For Teams actionable card use `ALERT_PROVIDER=teams`.
+2. (Optional) Add `ALERT_WEBHOOK_URL_TEST` to receive a harmless test payload before real notifications — useful for validating webhook formatting without sending the real alert.
+3. Create a test issue with label `monitor-failure` to trigger the notification. If `ALERT_WEBHOOK_URL_TEST` is set, the workflow will first POST a small test JSON to that URL and log the response status and body excerpt; then it will send the real provider-specific payload to `ALERT_WEBHOOK_URL`.
+4. The workflow sends provider-specific payloads (Slack Blocks for `slack`, actionable card for `teams`) and logs the webhook response status and a short response body excerpt in the action logs (helps with debugging).
+5. If you want a richer Slack message (blocks with button), use `ALERT_PROVIDER=slack` (default). For Teams actionable card use `ALERT_PROVIDER=teams`.
 
 
 ---


### PR DESCRIPTION
Adds an optional test payload step which POSTs a small harmless JSON to  (if set) before sending the real notification to . Also documents the test harness in README.,