### PR TITLE
chore(ci): refresh manual notify workflow registration

### DIFF
--- a/.github/workflows/notify_manual_test.yml
+++ b/.github/workflows/notify_manual_test.yml
@@ -1,4 +1,5 @@
 name: Manual notify test
+# NOTE: minor whitespace-only edit to refresh workflow registration (safe)
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Tiny no-op change to the manual notify workflow to force GitHub to re-evaluate workflow_dispatch availability (helps restore Run button).